### PR TITLE
Feature/44 mock custom user

### DIFF
--- a/src/test/java/com/gaejangmo/apiserver/model/common/support/WithMockCustomUser.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/common/support/WithMockCustomUser.java
@@ -10,9 +10,11 @@ import java.lang.annotation.RetentionPolicy;
 public @interface WithMockCustomUser {
     String id() default "1";
 
-    String oauthId() default "12345";
+    String oauthId() default "20608121";
 
-    String username() default "rob";
+    String username() default "JunHoPark93";
 
-    String email() default "example@gmail.com";
+    String email() default "abc@gmail.com";
+
+    String role() default "ROLE_USER";
 }

--- a/src/test/java/com/gaejangmo/apiserver/model/common/support/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/common/support/WithMockCustomUserSecurityContextFactory.java
@@ -3,9 +3,12 @@ package com.gaejangmo.apiserver.model.common.support;
 import com.gaejangmo.apiserver.config.oauth.SecurityUser;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.Set;
 
 public class WithMockCustomUserSecurityContextFactory
         implements WithSecurityContextFactory<WithMockCustomUser> {
@@ -19,6 +22,7 @@ public class WithMockCustomUserSecurityContextFactory
                 .oauthId(Long.valueOf(customUser.oauthId()))
                 .username(customUser.username())
                 .email(customUser.email())
+                .authorities(Set.of(new SimpleGrantedAuthority(customUser.role())))
                 .build();
 
         Authentication auth =

--- a/src/test/java/com/gaejangmo/apiserver/model/product/controller/ProductAcceptanceTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/product/controller/ProductAcceptanceTest.java
@@ -32,7 +32,7 @@ import static org.springframework.restdocs.webtestclient.WebTestClientRestDocume
 @AutoConfigureWebTestClient
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
-public class ProductAcceptanceTest {
+class ProductAcceptanceTest {
     private static final String PRODUCT_API = linkTo(ProductApiController.class).toString();
     private static final String LOCALHOST = "http://localhost:";
 
@@ -60,7 +60,7 @@ public class ProductAcceptanceTest {
     }
 
     @Test
-    @WithMockCustomUser(oauthId = "20608121", username = "JunHoPark93", email = "abc@gmail.com")
+    @WithMockCustomUser
     void 장비조회() {
         List<ManagedProductResponseDto> managedProductResponseDtoList = webTestClient.get()
                 .uri(uriBuilder ->


### PR DESCRIPTION
* @WithMockCustomUser 어노테이션에 role 필드를 추가했습니다. (default value : ROLE_USER)
* @WithMockCustomUser 어노테이션의 필드의 default value를 수정했습니다.
   * data.sql를 통해 실제 인 메모리에 들어갈 사용자 정보로 디폴트 값을 설정해뒀습니다.
   * 필드값을 특정한 상황아니면 따로 설정하지 않아도 테스트가 돌아갈 것입니다.

resolves: #44 