### PR TITLE
Feature/50 user rest docs

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -25,3 +25,67 @@ include::{snippets}/product/findFromInternalResource/http-response.adoc[]
 
 .response fields
 include::{snippets}/product/findFromInternalResource/response-fields.adoc[]
+
+== User
+=== checkLogin() API
+로그인 되어 있는지 확인
+
+.request
+include::{snippets}/sign/checkLogin/http-request.adoc[]
+
+.response
+include::{snippets}/sign/checkLogin/http-response.adoc[]
+
+=== showUser() API
+로그인 되어 있는 유저 정보 반환
+
+.request
+include::{snippets}/user/showUser/http-request.adoc[]
+
+.response
+include::{snippets}/user/showUser/http-response.adoc[]
+
+.response fields
+include::{snippets}/user/showUser/response-fields.adoc[]
+
+=== showUserByName API
+username으로 유저 정보 검색
+
+.request
+include::{snippets}/user/showUserByName/http-request.adoc[]
+
+.response
+include::{snippets}/user/showUserByName/http-response.adoc[]
+
+.response fields
+include::{snippets}/user/showUserByName/response-fields.adoc[]
+
+=== updateMotto API
+유저 Motto(좌우명) 수정
+
+.request
+include::{snippets}/user/updateMotto/http-request.adoc[]
+
+.request fields
+include::{snippets}/user/updateMotto/request-fields.adoc[]
+
+.response
+include::{snippets}/user/updateMotto/http-response.adoc[]
+
+.response fields
+include::{snippets}/user/updateMotto/response-fields.adoc[]
+
+=== updateUserImage API
+유저 프로필 사진 수정
+
+.request
+include::{snippets}/user/updateUserImage/http-request.adoc[]
+
+.request parts
+include::{snippets}/user/updateUserImage/request-parts.adoc[]
+
+.response
+include::{snippets}/user/updateUserImage/http-response.adoc[]
+
+.response fields
+include::{snippets}/user/updateUserImage/response-fields.adoc[]

--- a/src/main/java/com/gaejangmo/apiserver/config/SecurityConfig.java
+++ b/src/main/java/com/gaejangmo/apiserver/config/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/api/*/login/state").permitAll()
                 .antMatchers("/api/*/products/**").permitAll()
                 .antMatchers("/api/*/users/products/latest").permitAll()
+                .antMatchers(HttpMethod.GET, "/api/*/users/{name}").permitAll()
                 .antMatchers("/api/*/users/products/**").hasRole("USER")
                 .anyRequest().authenticated();
 

--- a/src/main/java/com/gaejangmo/apiserver/model/image/dto/FileResponseDto.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/image/dto/FileResponseDto.java
@@ -1,15 +1,13 @@
 package com.gaejangmo.apiserver.model.image.dto;
 
 import com.gaejangmo.apiserver.model.image.domain.vo.FileFeature;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Getter
 @ToString
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class FileResponseDto {
     private Long id;

--- a/src/main/java/com/gaejangmo/apiserver/model/user/controller/UserApiController.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/user/controller/UserApiController.java
@@ -41,10 +41,9 @@ public class UserApiController {
     }
 
     @PostMapping("/image")
-    public ResponseEntity<FileResponseDto> updateUserImage(@RequestParam("file") final MultipartFile multipartFile,
+    public ResponseEntity<FileResponseDto> updateUserImage(@RequestParam final MultipartFile file,
                                                            @LoginUser final SecurityUser securityUser) {
-
-        FileResponseDto fileResponseDto = userService.updateUserImage(multipartFile, securityUser.getId());
+        FileResponseDto fileResponseDto = userService.updateUserImage(file, securityUser.getId());
         return ResponseEntity.ok(fileResponseDto);
     }
 }

--- a/src/main/java/com/gaejangmo/apiserver/model/user/controller/UserApiController.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/user/controller/UserApiController.java
@@ -22,13 +22,13 @@ public class UserApiController {
     }
 
     @GetMapping("/logined")
-    public ResponseEntity<UserResponseDto> find(@LoginUser SecurityUser user) {
+    public ResponseEntity<UserResponseDto> showUser(@LoginUser SecurityUser user) {
         UserResponseDto response = userService.findUserResponseDtoByOauthId(user.getOauthId());
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/{name}")
-    public ResponseEntity<UserResponseDto> showUser(@PathVariable final String name) {
+    public ResponseEntity<UserResponseDto> showUserByName(@PathVariable final String name) {
         UserResponseDto response = userService.findUserResponseDtoByName(name);
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/com/gaejangmo/apiserver/model/user/domain/User.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/user/domain/User.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.Objects;
 import java.util.Optional;
 
 @Entity
@@ -102,10 +103,9 @@ public class User extends BaseTimeEntity {
     }
 
     public String getImageUrl() {
-        if (userImage == null) {
-            return imageUrl.value();
-        }
-        return userImage.getFileFeature().getUrl();
+        return Objects.isNull(userImage) ?
+                imageUrl.value()
+                : userImage.getFileFeature().getUrl();
     }
 
     public Optional<UserImage> getUserImage() {

--- a/src/main/java/com/gaejangmo/apiserver/model/user/domain/User.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/user/domain/User.java
@@ -102,7 +102,10 @@ public class User extends BaseTimeEntity {
     }
 
     public String getImageUrl() {
-        return imageUrl.value();
+        if (userImage == null) {
+            return imageUrl.value();
+        }
+        return userImage.getFileFeature().getUrl();
     }
 
     public Optional<UserImage> getUserImage() {

--- a/src/main/java/com/gaejangmo/apiserver/model/user/domain/vo/Motto.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/user/domain/vo/Motto.java
@@ -1,15 +1,16 @@
 package com.gaejangmo.apiserver.model.user.domain.vo;
 
 import com.gaejangmo.apiserver.model.user.exception.InvalidMottoException;
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.Embeddable;
 
-@Embeddable
+
+@Getter
+@ToString
 @EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Embeddable
 public class Motto {
     private static final int MAX_LENGTH = 10;
 

--- a/src/test/java/com/gaejangmo/apiserver/model/MockMvcTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/MockMvcTest.java
@@ -1,6 +1,8 @@
 package com.gaejangmo.apiserver.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -9,6 +11,7 @@ import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
@@ -29,8 +32,12 @@ public abstract class MockMvcTest {
     protected void setUp(WebApplicationContext webApplicationContext,
                          RestDocumentationContextProvider restDocumentation) {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
                 .apply(documentationConfiguration(restDocumentation))
                 .apply(springSecurity())
                 .build();
+
+        OBJECT_MAPPER.registerModule(new JavaTimeModule());
+        OBJECT_MAPPER.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 }

--- a/src/test/java/com/gaejangmo/apiserver/model/user/controller/SignApiControllerTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/user/controller/SignApiControllerTest.java
@@ -7,6 +7,8 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -16,31 +18,41 @@ class SignApiControllerTest extends MockMvcTest {
     private static final String SIGN_API = getApiUrl(SignApiController.class);
 
     @Test
-    void 로그인_상태_확인() throws Exception {
+    void 로그인_하지_않은_상태_확인() throws Exception {
+        // given
         ResultActions resultActions = mockMvc.perform(get(SIGN_API + "/login/state")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print());
+                .andDo(print())
+                .andDo(document("sign/checkLogin",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
 
+        // when
         String result = resultActions.andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn().getResponse().getContentAsString();
 
+        // then
         assertThat(Boolean.valueOf(result)).isFalse();
     }
 
     @Test
     @WithMockUser
     void 로그인_성공_상태_확인() throws Exception {
+        // given
         ResultActions resultActions = mockMvc.perform(get(SIGN_API + "/login/state")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print());
 
+        // when
         String result = resultActions.andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn().getResponse().getContentAsString();
 
+        // then
         assertThat(Boolean.valueOf(result)).isTrue();
     }
 }

--- a/src/test/java/com/gaejangmo/apiserver/model/user/controller/UserApiControllerTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/user/controller/UserApiControllerTest.java
@@ -1,11 +1,16 @@
 package com.gaejangmo.apiserver.model.user.controller;
 
+import com.gaejangmo.apiserver.config.aws.S3Connector;
 import com.gaejangmo.apiserver.model.MockMvcTest;
 import com.gaejangmo.apiserver.model.common.support.WithMockCustomUser;
+import com.gaejangmo.apiserver.model.image.domain.vo.FileFeature;
+import com.gaejangmo.apiserver.model.image.dto.FileResponseDto;
 import com.gaejangmo.apiserver.model.user.domain.vo.Motto;
 import com.gaejangmo.apiserver.model.user.dto.UserResponseDto;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithAnonymousUser;
@@ -13,11 +18,15 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import static com.gaejangmo.apiserver.model.user.testdata.UserTestData.RESPONSE_DTO;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -25,7 +34,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class UserApiControllerTest extends MockMvcTest {
     private static final String USER_API = getApiUrl(UserApiController.class);
 
-    FieldDescriptor[] userResponseDtoDescriptors = {fieldWithPath("id").type(JsonFieldType.NUMBER).description("식별자"),
+    @MockBean
+    private S3Connector s3Connector;
+
+    private FieldDescriptor[] userResponseDtoDescriptors = {fieldWithPath("id").type(JsonFieldType.NUMBER).description("식별자"),
             fieldWithPath("oauthId").type(JsonFieldType.NUMBER).description("oauth의 id"),
             fieldWithPath("username").type(JsonFieldType.STRING).description("사용자 이름"),
             fieldWithPath("email").type(JsonFieldType.STRING).description("사용자 이메일"),
@@ -55,20 +67,23 @@ class UserApiControllerTest extends MockMvcTest {
 
         UserResponseDto userResponseDto = OBJECT_MAPPER.readValue(contentAsByteArray, UserResponseDto.class);
 
-        assertThat(userResponseDto).isEqualTo(RESPONSE_DTO);
+        assertThat(userResponseDto.getId()).isEqualTo(RESPONSE_DTO.getId());
     }
 
     @Test
     @WithAnonymousUser
     void username으로_유저_정보_받기() throws Exception {
         // when
-        ResultActions resultActions = mockMvc.perform(get(USER_API + "/{name}", RESPONSE_DTO.getUsername())
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/users/{name}", RESPONSE_DTO.getUsername())
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andDo(document("user/showUserByName",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
+//                        pathParameters(
+//                                parameterWithName("name").description("검색하고 싶은 유저의 이름")
+//                        ),
                         responseFields(userResponseDtoDescriptors)
                 ));
 
@@ -115,4 +130,49 @@ class UserApiControllerTest extends MockMvcTest {
         assertThat(actual).isEqualTo(motto);
     }
 
+    @Test
+    @WithMockCustomUser
+    void UserImage_수정() throws Exception {
+        // given
+        MockMultipartFile file = new MockMultipartFile("file", "fileName.jpg", "image/jpeg", "image".getBytes());
+        String expectedUrl = "expected url";
+        when(s3Connector.upload(eq(file), anyString())).thenReturn(expectedUrl);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(multipart(USER_API + "/image")
+                .file(file)
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("user/updateUserImage",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestParts(
+                                partWithName("file").description("수정하려는 이미지 파일")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("식별자"),
+                                fieldWithPath("fileFeature.url").type(JsonFieldType.STRING).description("이미지를 호출할 수 있는 url"),
+                                fieldWithPath("fileFeature.imageType").type(JsonFieldType.STRING).description("이미지의 확장자"),
+                                fieldWithPath("fileFeature.originalName").type(JsonFieldType.STRING).description("파일의 원래 이름"),
+                                fieldWithPath("fileFeature.savedName").type(JsonFieldType.STRING).description("저장된 이름"),
+                                fieldWithPath("fileFeature.size").type(JsonFieldType.NUMBER).description("파일 크기"),
+                                fieldWithPath("createdAt").type(JsonFieldType.STRING).description("생성 날짜")
+                        )
+                ));
+
+        // then
+        byte[] contentAsByteArray = resultActions.andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andReturn().getResponse().getContentAsByteArray();
+
+        FileResponseDto fileResponseDto = OBJECT_MAPPER.readValue(contentAsByteArray, FileResponseDto.class);
+        FileFeature fileFeature = fileResponseDto.getFileFeature();
+
+        assertThat(fileFeature.getSize()).isEqualTo(file.getSize());
+        assertThat(fileFeature.getImageType()).isEqualTo(file.getContentType());
+        assertThat(fileFeature.getOriginalName()).isEqualTo(file.getOriginalFilename());
+        assertThat(fileFeature.getUrl()).isEqualTo(expectedUrl);
+        assertThat(fileFeature.getSavedName()).isNotBlank();
+    }
 }

--- a/src/test/java/com/gaejangmo/apiserver/model/user/controller/UserApiControllerTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/user/controller/UserApiControllerTest.java
@@ -2,14 +2,22 @@ package com.gaejangmo.apiserver.model.user.controller;
 
 import com.gaejangmo.apiserver.model.MockMvcTest;
 import com.gaejangmo.apiserver.model.common.support.WithMockCustomUser;
+import com.gaejangmo.apiserver.model.user.domain.vo.Motto;
 import com.gaejangmo.apiserver.model.user.dto.UserResponseDto;
-import com.gaejangmo.apiserver.model.user.testdata.UserTestData;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static com.gaejangmo.apiserver.model.user.testdata.UserTestData.RESPONSE_DTO;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -17,23 +25,94 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class UserApiControllerTest extends MockMvcTest {
     private static final String USER_API = getApiUrl(UserApiController.class);
 
+    FieldDescriptor[] userResponseDtoDescriptors = {fieldWithPath("id").type(JsonFieldType.NUMBER).description("식별자"),
+            fieldWithPath("oauthId").type(JsonFieldType.NUMBER).description("oauth의 id"),
+            fieldWithPath("username").type(JsonFieldType.STRING).description("사용자 이름"),
+            fieldWithPath("email").type(JsonFieldType.STRING).description("사용자 이메일"),
+            fieldWithPath("motto").type(JsonFieldType.STRING).description("좌우명"),
+            fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("프로필 사진"),
+            fieldWithPath("introduce").type(JsonFieldType.STRING).description("소개")};
+
+
     @Test
     @WithMockCustomUser
-    void 사용자_로그인_시_로그인_정보_반환() throws Exception {
-        // given
+    void 사용자_로그인_시_정보_반환() throws Exception {
+        // when
         ResultActions resultActions = mockMvc.perform(get(USER_API + "/logined")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print());
+                .andDo(print())
+                .andDo(document("user/showUser",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(userResponseDtoDescriptors)
+                ));
 
-        // when
+        // then
         byte[] contentAsByteArray = resultActions.andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn().getResponse().getContentAsByteArray();
 
-        // then
         UserResponseDto userResponseDto = OBJECT_MAPPER.readValue(contentAsByteArray, UserResponseDto.class);
 
-        assertThat(userResponseDto).isEqualTo(UserTestData.RESPONSE_DTO);
+        assertThat(userResponseDto).isEqualTo(RESPONSE_DTO);
     }
+
+    @Test
+    @WithAnonymousUser
+    void username으로_유저_정보_받기() throws Exception {
+        // when
+        ResultActions resultActions = mockMvc.perform(get(USER_API + "/{name}", RESPONSE_DTO.getUsername())
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("user/showUserByName",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(userResponseDtoDescriptors)
+                ));
+
+        // then
+        byte[] contentAsByteArray = resultActions.andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andReturn().getResponse().getContentAsByteArray();
+
+        UserResponseDto userResponseDto = OBJECT_MAPPER.readValue(contentAsByteArray, UserResponseDto.class);
+
+        assertThat(userResponseDto).isEqualTo(RESPONSE_DTO);
+    }
+
+    @Test
+    @WithMockCustomUser
+    void Motto_수정() throws Exception {
+        // given
+        Motto motto = Motto.of("game");
+
+        // when
+        ResultActions resultActions = mockMvc.perform(put(USER_API + "/motto")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(OBJECT_MAPPER.writeValueAsString(motto)))
+                .andDo(print())
+                .andDo(document("user/updateMotto",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("value").type(JsonFieldType.STRING).description("수정하려는 좌우명")
+                        ),
+                        responseFields(
+                                fieldWithPath("value").type(JsonFieldType.STRING).description("좌우명")
+                        )
+                ));
+
+        // then
+        byte[] contentAsByteArray = resultActions.andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andReturn().getResponse().getContentAsByteArray();
+
+        Motto actual = OBJECT_MAPPER.readValue(contentAsByteArray, Motto.class);
+
+        assertThat(actual).isEqualTo(motto);
+    }
+
 }

--- a/src/test/java/com/gaejangmo/apiserver/model/user/controller/UserApiControllerTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/user/controller/UserApiControllerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithAnonymousUser;
@@ -24,8 +25,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -74,16 +74,17 @@ class UserApiControllerTest extends MockMvcTest {
     @WithAnonymousUser
     void username으로_유저_정보_받기() throws Exception {
         // when
-        ResultActions resultActions = mockMvc.perform(get("/api/v1/users/{name}", RESPONSE_DTO.getUsername())
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(MediaType.APPLICATION_JSON))
+        ResultActions resultActions = mockMvc.perform(
+                RestDocumentationRequestBuilders.get("/api/v1/users/{name}", RESPONSE_DTO.getUsername())
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andDo(document("user/showUserByName",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
-//                        pathParameters(
-//                                parameterWithName("name").description("검색하고 싶은 유저의 이름")
-//                        ),
+                        pathParameters(
+                                parameterWithName("name").description("검색하고 싶은 유저의 이름")
+                        ),
                         responseFields(userResponseDtoDescriptors)
                 ));
 

--- a/src/test/java/com/gaejangmo/apiserver/model/user/domain/UserTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/user/domain/UserTest.java
@@ -1,10 +1,14 @@
 package com.gaejangmo.apiserver.model.user.domain;
 
 import com.gaejangmo.apiserver.model.common.domain.vo.Link;
+import com.gaejangmo.apiserver.model.image.domain.vo.FileFeature;
+import com.gaejangmo.apiserver.model.image.domain.vo.ImageType;
+import com.gaejangmo.apiserver.model.image.user.domain.UserImage;
 import com.gaejangmo.apiserver.model.user.domain.vo.Email;
 import com.gaejangmo.apiserver.model.user.domain.vo.Motto;
 import com.gaejangmo.apiserver.model.user.domain.vo.Role;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -42,5 +46,38 @@ class UserTest {
 
         assertThat(user.matchId(id)).isTrue();
         assertThat(user.matchId(2L)).isFalse();
+    }
+
+    @Test
+    @DisplayName("getImageUrl() 했을 때 UserImage가 null이면 imageUrl을 반환해야 한다.")
+    void getImageUrl01() {
+        user.updateUserImage(null);
+        String imageUrl = user.getImageUrl();
+
+        assertThat(imageUrl).isNotNull();
+    }
+
+    @Test
+    @DisplayName("getImageUrl() 했을 때 UserImage가 null이 아니면 UserImage를 반환해야 한다.")
+    void getImageUrl02() {
+        // given
+        UserImage userImage = UserImage.builder()
+                .fileFeature(
+                        FileFeature.builder().url("url")
+                                .savedName("savedName")
+                                .originalName("originalName")
+                                .size(11)
+                                .imageType(ImageType.of("jpg"))
+                                .build())
+                .build();
+
+        String expected = userImage.getFileFeature().getUrl();
+
+        // when
+        user.updateUserImage(userImage);
+        String actual = user.getImageUrl();
+
+        // then
+        assertThat(actual).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
Rest Docs에 pathVariable 을 추가하기 위해서 pathParameters()을 사용해줬더니 아래 메시지가 나오면서 테스트가 실패합니다. 

#### 예외 메시지
```
java.lang.IllegalArgumentException: urlTemplate not found. If you are using MockMvc did you use RestDocumentationRequestBuilders to build the request?
```

#### 해당 코드 
```java
.andDo(document("user/showUserByName",
      preprocessRequest(prettyPrint()),
      preprocessResponse(prettyPrint()),
      pathParameters(
      		parameterWithName("name").description("검색하고 싶은 유저의 이름")
      ),
      responseFields(userResponseDtoDescriptors)
));
```

#### 레퍼런스 
If you use MockMvc, to make the path parameters available for documentation, you must build the request by using one of the methods on `RestDocumentationRequestBuilders` rather than `MockMvcRequestBuilders`.

[링크](https://docs.spring.io/spring-restdocs/docs/2.0.4.RELEASE/reference/html5/#documenting-your-api-path-parameters)

라고 나와서 일단은 주석처리 하고 넘어갔습니다.

resloves: #50 