### PR TITLE
UserProductCreateDto.productType String으로 타입 수정

### DIFF
--- a/src/main/java/com/gaejangmo/apiserver/model/userproduct/service/UserProductService.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/userproduct/service/UserProductService.java
@@ -110,7 +110,7 @@ public class UserProductService {
         return UserProduct.builder()
                 .user(user)
                 .product(product)
-                .productType(userProductCreateDto.getProductType())
+                .productType(ProductType.ofName(userProductCreateDto.getProductType()))
                 .comment(Comment.of(userProductCreateDto.getComment()))
                 .build();
     }

--- a/src/main/java/com/gaejangmo/apiserver/model/userproduct/service/dto/UserProductCreateDto.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/userproduct/service/dto/UserProductCreateDto.java
@@ -1,6 +1,5 @@
 package com.gaejangmo.apiserver.model.userproduct.service.dto;
 
-import com.gaejangmo.apiserver.model.userproduct.domain.vo.ProductType;
 import lombok.*;
 
 @Getter
@@ -9,11 +8,11 @@ import lombok.*;
 @EqualsAndHashCode
 public class UserProductCreateDto {
     private String comment;
-    private ProductType productType;
+    private String productType;
     private Long productId;
 
     @Builder
-    public UserProductCreateDto(final String comment, final ProductType productType, final Long productId) {
+    public UserProductCreateDto(final String comment, final String productType, final Long productId) {
         this.comment = comment;
         this.productType = productType;
         this.productId = productId;

--- a/src/test/java/com/gaejangmo/apiserver/model/userproduct/controller/UserProductApiControllerTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/userproduct/controller/UserProductApiControllerTest.java
@@ -35,7 +35,7 @@ class UserProductApiControllerTest extends MockMvcTest {
     void setUp() {
         userProductCreateDto = UserProductCreateDto.builder()
                 .productId(PRODUCT_ID)
-                .productType(ProductType.KEY_BOARD)
+                .productType(ProductType.MOUSE.getName())
                 .comment("인생 마우스")
                 .build();
 


### PR DESCRIPTION
클라이언트가 `키보드`로 요청할 때 ProductTypeConverter가 실행 안되는 문제 때문에 
UserProductCreateDto.ProductType String으로 수정했습니다.

(규동하고 이야기한 부분)

resolves: #57 