### PR TITLE
Feature/67 operation preprocessor

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -15,6 +15,7 @@ gaejangmo.com
 == Product API
 
 === save()
+장비 저장
 
 .request
 include::{snippets}/product/save/http-request.adoc[]
@@ -26,6 +27,8 @@ include::{snippets}/product/save/request-fields.adoc[]
 include::{snippets}/product/save/http-response.adoc[]
 
 === findFromInternalResource()
+DB에 저장된 장비 조회
+
 .request
 include::{snippets}/product/findFromInternalResource/http-request.adoc[]
 
@@ -39,7 +42,10 @@ include::{snippets}/product/findFromInternalResource/http-response.adoc[]
 include::{snippets}/product/findFromInternalResource/response-fields.adoc[]
 
 == Notice API
+
 === save()
+공지 저장
+
 .request
 include::{snippets}/notice/save/http-request.adoc[]
 
@@ -50,6 +56,8 @@ include::{snippets}/notice/save/request-fields.adoc[]
 include::{snippets}/notice/save/http-response.adoc[]
 
 === find()
+공지 조회
+
 .request
 include::{snippets}/notice/http-request.adoc[]
 
@@ -63,6 +71,7 @@ include::{snippets}/notice/http-response.adoc[]
 include::{snippets}/notice/response-fields.adoc[]
 
 == User API
+
 === checkLogin()
 로그인 되어 있는지 확인
 
@@ -84,7 +93,7 @@ include::{snippets}/user/showUser/http-response.adoc[]
 .response fields
 include::{snippets}/user/showUser/response-fields.adoc[]
 
-=== showUserByName API
+=== showUserByName()
 username으로 유저 정보 검색
 
 .request
@@ -96,7 +105,7 @@ include::{snippets}/user/showUserByName/http-response.adoc[]
 .response fields
 include::{snippets}/user/showUserByName/response-fields.adoc[]
 
-=== updateMotto API
+=== updateMotto()
 유저 Motto(좌우명) 수정
 
 .request
@@ -111,7 +120,7 @@ include::{snippets}/user/updateMotto/http-response.adoc[]
 .response fields
 include::{snippets}/user/updateMotto/response-fields.adoc[]
 
-=== updateUserImage API
+=== updateUserImage()
 유저 프로필 사진 수정
 
 .request

--- a/src/test/java/com/gaejangmo/apiserver/model/common/support/ApiDocumentUtils.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/common/support/ApiDocumentUtils.java
@@ -13,7 +13,7 @@ public class ApiDocumentUtils {
         return preprocessRequest(
                 modifyUris()
                         .scheme("https")
-                        .host("docs.api.com")
+                        .host("gaejangmo.com")
                         .removePort(),
                 prettyPrint());
     }

--- a/src/test/java/com/gaejangmo/apiserver/model/notice/controller/NoticeApiControllerTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/notice/controller/NoticeApiControllerTest.java
@@ -10,6 +10,8 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static com.gaejangmo.apiserver.model.common.support.ApiDocumentUtils.getDocumentRequest;
+import static com.gaejangmo.apiserver.model.common.support.ApiDocumentUtils.getDocumentResponse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -32,6 +34,8 @@ class NoticeApiControllerTest extends MockMvcTest {
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andDo(document("notice/save",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
                         requestFields(
                                 fieldWithPath("noticeType").type(JsonFieldType.STRING).description("공지 타입"),
                                 fieldWithPath("header").type(JsonFieldType.STRING).description("공지 헤더"),
@@ -49,6 +53,8 @@ class NoticeApiControllerTest extends MockMvcTest {
 
         byte[] contentAsByteArray = resultActions.andExpect(status().isOk())
                 .andDo(document("notice",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
                         pathParameters(
                                 parameterWithName("id").description("공지 고유 번호")
                         ),

--- a/src/test/java/com/gaejangmo/apiserver/model/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/product/controller/ProductApiControllerTest.java
@@ -13,6 +13,8 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.List;
 
+import static com.gaejangmo.apiserver.model.common.support.ApiDocumentUtils.getDocumentRequest;
+import static com.gaejangmo.apiserver.model.common.support.ApiDocumentUtils.getDocumentResponse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -70,6 +72,8 @@ class ProductApiControllerTest extends MockMvcTest {
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andDo(document("product/save",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
                         requestFields(
                                 fieldWithPath("title").type(JsonFieldType.STRING).description("제품 이름"),
                                 fieldWithPath("link").type(JsonFieldType.STRING).description("제품 판매 경로"),
@@ -88,6 +92,8 @@ class ProductApiControllerTest extends MockMvcTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andDo(document("product/findFromInternalResource",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
                         requestParameters(
                                 parameterWithName("productName").description("제품 이름")
                         ),

--- a/src/test/java/com/gaejangmo/apiserver/model/user/controller/SignApiControllerTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/user/controller/SignApiControllerTest.java
@@ -6,9 +6,10 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static com.gaejangmo.apiserver.model.common.support.ApiDocumentUtils.getDocumentRequest;
+import static com.gaejangmo.apiserver.model.common.support.ApiDocumentUtils.getDocumentResponse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -25,8 +26,8 @@ class SignApiControllerTest extends MockMvcTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andDo(document("sign/checkLogin",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        getDocumentRequest(),
+                        getDocumentResponse()
                 ));
 
         // when

--- a/src/test/java/com/gaejangmo/apiserver/model/user/controller/UserApiControllerTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/user/controller/UserApiControllerTest.java
@@ -17,6 +17,8 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static com.gaejangmo.apiserver.model.common.support.ApiDocumentUtils.getDocumentRequest;
+import static com.gaejangmo.apiserver.model.common.support.ApiDocumentUtils.getDocumentResponse;
 import static com.gaejangmo.apiserver.model.user.testdata.UserTestData.RESPONSE_DTO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -55,8 +57,8 @@ class UserApiControllerTest extends MockMvcTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andDo(document("user/showUser",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
+                        getDocumentRequest(),
+                        getDocumentResponse(),
                         responseFields(userResponseDtoDescriptors)
                 ));
 


### PR DESCRIPTION
rest docs 생성 전 처리기에 `ApiDocumentUtils` 클래스의 정적 메서드를 테스트 코드 모두에 적용했습니다.
다른 테스트 코드를 작성하실 때 참고하시면 될거에요~

resolves: #67 