### PR TITLE
Feature/65 like 기능 구현

### DIFF
--- a/src/main/java/com/gaejangmo/apiserver/model/like/domain/LikeRepository.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/like/domain/LikeRepository.java
@@ -4,9 +4,12 @@ import com.gaejangmo.apiserver.model.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Likes, Long> {
     List<Likes> findAllBySource(final User source);
+
+    Optional<Likes> findBySourceAndTarget(final User source, final User target);
 
     void deleteBySourceAndTarget(final User source, final User target);
 }

--- a/src/main/java/com/gaejangmo/apiserver/model/like/domain/LikeRepository.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/like/domain/LikeRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface LikeRepository extends JpaRepository<Likes, Long> {
     List<Likes> findAllBySource(final User source);
+
+    void deleteBySourceAndTarget(final User source, final User target);
 }

--- a/src/main/java/com/gaejangmo/apiserver/model/like/domain/LikeRepository.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/like/domain/LikeRepository.java
@@ -1,0 +1,6 @@
+package com.gaejangmo.apiserver.model.like.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Likes, Long> {
+}

--- a/src/main/java/com/gaejangmo/apiserver/model/like/domain/LikeRepository.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/like/domain/LikeRepository.java
@@ -1,6 +1,10 @@
 package com.gaejangmo.apiserver.model.like.domain;
 
+import com.gaejangmo.apiserver.model.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LikeRepository extends JpaRepository<Likes, Long> {
+    List<Likes> findAllBySource(final User source);
 }

--- a/src/main/java/com/gaejangmo/apiserver/model/like/domain/Likes.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/like/domain/Likes.java
@@ -1,0 +1,35 @@
+package com.gaejangmo.apiserver.model.like.domain;
+
+import com.gaejangmo.apiserver.model.common.domain.BaseTimeEntity;
+import com.gaejangmo.apiserver.model.user.domain.User;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@EqualsAndHashCode(of = "id", callSuper = false)
+public class Likes extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_source_id", foreignKey = @ForeignKey(name = "fk_user_to_source_likes"))
+    private User source;
+
+    @ManyToOne
+    @JoinColumn(name = "user_target_id", foreignKey = @ForeignKey(name = "fk_user_to_likes_target"))
+    private User target;
+
+    @Builder
+    public Likes(final User source, final User target) {
+        this.source = source;
+        this.target = target;
+    }
+}

--- a/src/main/java/com/gaejangmo/apiserver/model/like/service/LikeService.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/like/service/LikeService.java
@@ -5,10 +5,12 @@ import com.gaejangmo.apiserver.model.like.domain.Likes;
 import com.gaejangmo.apiserver.model.user.domain.User;
 import com.gaejangmo.apiserver.model.user.service.UserService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
+@Transactional
 public class LikeService {
     private final LikeRepository likeRepository;
     private final UserService userService;
@@ -30,8 +32,15 @@ public class LikeService {
         likeRepository.save(like);
     }
 
+    @Transactional(readOnly = true)
     public List<Likes> findAllBySource(final Long sourceId) {
         User source = userService.findById(sourceId);
         return likeRepository.findAllBySource(source);
+    }
+
+    public void deleteBySourceAndTarget(final Long sourceId, final Long targetId) {
+        User source = userService.findById(sourceId);
+        User target = userService.findById(targetId);
+        likeRepository.deleteBySourceAndTarget(source, target);
     }
 }

--- a/src/main/java/com/gaejangmo/apiserver/model/like/service/LikeService.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/like/service/LikeService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional
@@ -35,12 +36,23 @@ public class LikeService {
     @Transactional(readOnly = true)
     public List<Likes> findAllBySource(final Long sourceId) {
         User source = userService.findById(sourceId);
+
         return likeRepository.findAllBySource(source);
     }
 
     public void deleteBySourceAndTarget(final Long sourceId, final Long targetId) {
         User source = userService.findById(sourceId);
         User target = userService.findById(targetId);
+
         likeRepository.deleteBySourceAndTarget(source, target);
+    }
+
+    public boolean isLiked(final Long sourceId, final Long targetId) {
+        User source = userService.findById(sourceId);
+        User target = userService.findById(targetId);
+
+        Optional<Likes> like = likeRepository.findBySourceAndTarget(source, target);
+
+        return like.isPresent();
     }
 }

--- a/src/main/java/com/gaejangmo/apiserver/model/like/service/LikeService.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/like/service/LikeService.java
@@ -49,6 +49,7 @@ public class LikeService {
         likeRepository.deleteBySourceAndTarget(source, target);
     }
 
+    @Transactional(readOnly = true)
     public boolean isLiked(final SecurityUser loginUser, final Long targetId) {
         if (Objects.isNull(loginUser)) {
             return false;

--- a/src/main/java/com/gaejangmo/apiserver/model/like/service/LikeService.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/like/service/LikeService.java
@@ -1,0 +1,37 @@
+package com.gaejangmo.apiserver.model.like.service;
+
+import com.gaejangmo.apiserver.model.like.domain.LikeRepository;
+import com.gaejangmo.apiserver.model.like.domain.Likes;
+import com.gaejangmo.apiserver.model.user.domain.User;
+import com.gaejangmo.apiserver.model.user.service.UserService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class LikeService {
+    private final LikeRepository likeRepository;
+    private final UserService userService;
+
+    public LikeService(final LikeRepository likeRepository, final UserService userService) {
+        this.likeRepository = likeRepository;
+        this.userService = userService;
+    }
+
+    public void save(final Long sourceId, final Long targetId) {
+        User source = userService.findById(sourceId);
+        User target = userService.findById(targetId);
+
+        Likes like = Likes.builder()
+                .source(source)
+                .target(target)
+                .build();
+
+        likeRepository.save(like);
+    }
+
+    public List<Likes> findAllBySource(final Long sourceId) {
+        User source = userService.findById(sourceId);
+        return likeRepository.findAllBySource(source);
+    }
+}

--- a/src/main/java/com/gaejangmo/apiserver/model/like/service/LikeService.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/like/service/LikeService.java
@@ -1,5 +1,6 @@
 package com.gaejangmo.apiserver.model.like.service;
 
+import com.gaejangmo.apiserver.config.oauth.SecurityUser;
 import com.gaejangmo.apiserver.model.like.domain.LikeRepository;
 import com.gaejangmo.apiserver.model.like.domain.Likes;
 import com.gaejangmo.apiserver.model.user.domain.User;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -47,8 +49,12 @@ public class LikeService {
         likeRepository.deleteBySourceAndTarget(source, target);
     }
 
-    public boolean isLiked(final Long sourceId, final Long targetId) {
-        User source = userService.findById(sourceId);
+    public boolean isLiked(final SecurityUser loginUser, final Long targetId) {
+        if (Objects.isNull(loginUser)) {
+            return false;
+        }
+
+        User source = userService.findById(loginUser.getId());
         User target = userService.findById(targetId);
 
         Optional<Likes> like = likeRepository.findBySourceAndTarget(source, target);

--- a/src/main/java/com/gaejangmo/apiserver/model/user/controller/UserApiController.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/user/controller/UserApiController.java
@@ -11,6 +11,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @EnableLog
 @RestController
 @RequestMapping("/api/v1/users")
@@ -28,9 +30,15 @@ public class UserApiController {
     }
 
     @GetMapping("/{name}")
-    public ResponseEntity<UserResponseDto> showUserByName(@PathVariable final String name) {
-        UserResponseDto response = userService.findUserResponseDtoByName(name);
-        return ResponseEntity.ok().body(response);
+    public ResponseEntity<UserResponseDto> showUserByName(@PathVariable final String name, @LoginUser SecurityUser securityUser) {
+        UserResponseDto response = userService.findUserResponseDtoByName(name, securityUser);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/likes")
+    public ResponseEntity<List<UserResponseDto>> showLikeUser(@LoginUser SecurityUser securityUser) {
+        List<UserResponseDto> response = userService.findUserResponseDtoBySourceId(securityUser.getId());
+        return ResponseEntity.ok(response);
     }
 
     @PutMapping("/motto")

--- a/src/main/java/com/gaejangmo/apiserver/model/user/dto/UserResponseDto.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/user/dto/UserResponseDto.java
@@ -1,11 +1,13 @@
 package com.gaejangmo.apiserver.model.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 
 @Getter
 @ToString
 @NoArgsConstructor
 @EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class UserResponseDto {
     private Long id;
     private Long oauthId;
@@ -14,9 +16,11 @@ public class UserResponseDto {
     private String motto;
     private String imageUrl;
     private String introduce;
+    private Boolean isLiked;
 
     @Builder
-    public UserResponseDto(final Long id, final Long oauthId, final String username, final String email, final String motto, final String imageUrl, final String introduce) {
+    public UserResponseDto(final Long id, final Long oauthId, final String username, final String email,
+                           final String motto, final String imageUrl, final String introduce, final Boolean isLiked) {
         this.id = id;
         this.oauthId = oauthId;
         this.username = username;
@@ -24,6 +28,7 @@ public class UserResponseDto {
         this.motto = motto;
         this.imageUrl = imageUrl;
         this.introduce = introduce;
+        this.isLiked = isLiked;
     }
 }
 

--- a/src/main/java/com/gaejangmo/apiserver/model/user/service/UserService.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/user/service/UserService.java
@@ -3,6 +3,8 @@ package com.gaejangmo.apiserver.model.user.service;
 import com.gaejangmo.apiserver.model.image.domain.user.service.UserImageService;
 import com.gaejangmo.apiserver.model.image.dto.FileResponseDto;
 import com.gaejangmo.apiserver.model.image.user.domain.UserImage;
+import com.gaejangmo.apiserver.model.like.domain.Likes;
+import com.gaejangmo.apiserver.model.like.service.LikeService;
 import com.gaejangmo.apiserver.model.user.domain.User;
 import com.gaejangmo.apiserver.model.user.domain.UserRepository;
 import com.gaejangmo.apiserver.model.user.domain.vo.Motto;
@@ -12,8 +14,10 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.EntityNotFoundException;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -21,10 +25,12 @@ public class UserService {
     private static final String USER_NOT_FOUND_MESSAGE = "해당하는 유저가 없습니다.";
     private final UserRepository userRepository;
     private final UserImageService userImageService;
+    private final LikeService likeService;
 
-    public UserService(final UserRepository userRepository, final UserImageService userImageService) {
+    public UserService(final UserRepository userRepository, final UserImageService userImageService, final LikeService likeService) {
         this.userRepository = userRepository;
         this.userImageService = userImageService;
+        this.likeService = likeService;
     }
 
     @Transactional(readOnly = true)
@@ -74,6 +80,14 @@ public class UserService {
                 .id(savedUserImage.getId())
                 .fileFeature(savedUserImage.getFileFeature())
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserResponseDto> findUserResponseDtoBySourceId(final Long sourceId) {
+        return likeService.findAllBySource(sourceId).stream()
+                .map(Likes::getTarget)
+                .map(this::toDto)
+                .collect(Collectors.toList());
     }
 
     private UserResponseDto toDto(final User user) {

--- a/src/main/java/com/gaejangmo/apiserver/model/userproduct/controller/UserProductApiController.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/userproduct/controller/UserProductApiController.java
@@ -50,8 +50,9 @@ public class UserProductApiController {
 
     @GetMapping("/latest")
     public ResponseEntity<List<UserProductLatestResponseDto>> latest(
-            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) final Pageable pageable) {
-        List<UserProductLatestResponseDto> responseDtos = userProductService.findAllByPageable(pageable);
+            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) final Pageable pageable,
+            @LoginUser SecurityUser securityUser) {
+        List<UserProductLatestResponseDto> responseDtos = userProductService.findAllByPageable(pageable, securityUser);
         return ResponseEntity.ok(responseDtos);
     }
 

--- a/src/main/java/com/gaejangmo/apiserver/model/userproduct/service/UserProductService.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/userproduct/service/UserProductService.java
@@ -81,11 +81,6 @@ public class UserProductService {
         throw new NotUserProductOwnerException();
     }
 
-    public List<UserProductLatestResponseDto> findAllByPageable(final Pageable pageable) {
-        return userProductRepository.findAll(pageable)
-                .map(this::toLatestDto).toList();
-    }
-
     public List<UserProductLatestResponseDto> findAllByPageable(final Pageable pageable, final SecurityUser loginUser) {
         return userProductRepository.findAll(pageable)
                 .map(userProduct -> toLatestDto(userProduct,
@@ -103,19 +98,6 @@ public class UserProductService {
                 .username(userProduct.getUser().getUsername())
                 .motto(userProduct.getUser().getMotto())
                 .isLiked(isLiked)
-                .createdAt(userProduct.getCreatedAt())
-                .build();
-    }
-
-    private UserProductLatestResponseDto toLatestDto(final UserProduct userProduct) {
-        return UserProductLatestResponseDto.builder()
-                .id(userProduct.getId())
-                .productType(userProduct.getProductType())
-                .productImageUrl(userProduct.getProduct().getImageUrl())
-                .productName(userProduct.getProduct().getProductName())
-                .userImageUrl(userProduct.getUser().getImageUrl())
-                .username(userProduct.getUser().getUsername())
-                .motto(userProduct.getUser().getMotto())
                 .createdAt(userProduct.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/gaejangmo/apiserver/model/userproduct/service/dto/UserProductLatestResponseDto.java
+++ b/src/main/java/com/gaejangmo/apiserver/model/userproduct/service/dto/UserProductLatestResponseDto.java
@@ -20,7 +20,7 @@ public class UserProductLatestResponseDto {
     @Builder
     public UserProductLatestResponseDto(final Long id, final ProductType productType, final String productImageUrl,
                                         final String productName, final String userImageUrl, final String username,
-                                        final String motto, final LocalDateTime createdAt) {
+                                        final String motto, final boolean isLiked, final LocalDateTime createdAt) {
         this.id = id;
         this.product.put("type", productType);
         this.product.put("imageUrl", productImageUrl);
@@ -28,6 +28,7 @@ public class UserProductLatestResponseDto {
         this.user.put("imageUrl", userImageUrl);
         this.user.put("username", username);
         this.user.put("motto", motto);
+        this.user.put("isLiked", isLiked);
         this.createdAt = createdAt;
     }
 }

--- a/src/test/java/com/gaejangmo/apiserver/model/like/domain/LikesTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/like/domain/LikesTest.java
@@ -1,0 +1,42 @@
+package com.gaejangmo.apiserver.model.like.domain;
+
+import com.gaejangmo.apiserver.model.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+
+class LikesTest {
+    private Likes like;
+
+    @BeforeEach
+    void setUp() {
+        User source = mock(User.class);
+        User target = mock(User.class);
+
+        like = Likes.builder()
+                .source(source)
+                .target(target)
+                .build();
+    }
+
+    @Test
+    void 좋아요_동등성_테스트() {
+        assertThat(like).isEqualTo(
+                Likes.builder()
+                        .source(mock(User.class))
+                        .target(mock(User.class))
+                        .build());
+    }
+
+    @Test
+    void 도메인_생성_오류_확인() {
+        assertDoesNotThrow(() ->
+                Likes.builder()
+                        .source(mock(User.class))
+                        .target(mock(User.class))
+                        .build());
+    }
+}

--- a/src/test/java/com/gaejangmo/apiserver/model/like/service/LikeServiceTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/like/service/LikeServiceTest.java
@@ -4,7 +4,7 @@ import com.gaejangmo.apiserver.config.oauth.SecurityUser;
 import com.gaejangmo.apiserver.model.like.domain.LikeRepository;
 import com.gaejangmo.apiserver.model.like.domain.Likes;
 import com.gaejangmo.apiserver.model.user.domain.User;
-import com.gaejangmo.apiserver.model.user.service.UserService;
+import com.gaejangmo.apiserver.model.user.domain.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -33,14 +33,14 @@ class LikeServiceTest {
     private LikeRepository likeRepository;
 
     @Mock
-    private UserService userService;
+    private UserRepository userRepository;
 
     private SecurityUser loginUser = null;
 
     @Test
     void 좋아요_저장() {
         // given
-        given(userService.findById(anyLong())).willReturn(mock(User.class));
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(mock(User.class)));
         given(likeRepository.save(any())).willReturn(mock(Likes.class));
 
         // when & then
@@ -55,7 +55,7 @@ class LikeServiceTest {
                 .target(mock(User.class))
                 .build();
 
-        given(userService.findById(SOURCE_ID)).willReturn(mock(User.class));
+        given(userRepository.findById(SOURCE_ID)).willReturn(Optional.of(mock(User.class)));
         given(likeRepository.findAllBySource(any())).willReturn(List.of(like));
 
         // when
@@ -63,19 +63,19 @@ class LikeServiceTest {
 
         // then
         assertThat(likes).isEqualTo(List.of(like));
-        verify(userService, times(1)).findById(SOURCE_ID);
+        verify(userRepository, times(1)).findById(SOURCE_ID);
         verify(likeRepository, times(1)).findAllBySource(any());
     }
 
     @Test
     void 좋아요_취소() {
         // given
-        given(userService.findById(anyLong())).willReturn(mock(User.class));
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(mock(User.class)));
         doNothing().when(likeRepository).deleteBySourceAndTarget(any(), any());
 
         // when & then
         assertDoesNotThrow(() -> likeService.deleteBySourceAndTarget(SOURCE_ID, TARGET_ID));
-        verify(userService, times(2)).findById(anyLong());
+        verify(userRepository, times(2)).findById(anyLong());
         verify(likeRepository, times(1)).deleteBySourceAndTarget(any(), any());
     }
 
@@ -84,7 +84,7 @@ class LikeServiceTest {
         // given
         loginUser = SecurityUser.builder().id(SOURCE_ID).build();
 
-        given(userService.findById(anyLong())).willReturn(mock(User.class));
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(mock(User.class)));
         given(likeRepository.findBySourceAndTarget(any(), any())).willReturn(Optional.of(mock(Likes.class)));
 
         // when & then
@@ -96,7 +96,7 @@ class LikeServiceTest {
         // given
         loginUser = SecurityUser.builder().id(SOURCE_ID).build();
 
-        given(userService.findById(anyLong())).willReturn(mock(User.class));
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(mock(User.class)));
         given(likeRepository.findBySourceAndTarget(any(), any())).willReturn(Optional.empty());
 
         // when & then

--- a/src/test/java/com/gaejangmo/apiserver/model/like/service/LikeServiceTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/like/service/LikeServiceTest.java
@@ -1,0 +1,65 @@
+package com.gaejangmo.apiserver.model.like.service;
+
+import com.gaejangmo.apiserver.model.like.domain.LikeRepository;
+import com.gaejangmo.apiserver.model.like.domain.Likes;
+import com.gaejangmo.apiserver.model.user.domain.User;
+import com.gaejangmo.apiserver.model.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LikeServiceTest {
+    private static final Long SOURCE_ID = 1L;
+    private static final Long TARGET_ID = 2L;
+
+    @InjectMocks
+    private LikeService likeService;
+
+    @Mock
+    private LikeRepository likeRepository;
+
+    @Mock
+    private UserService userService;
+
+    @Test
+    void 좋아요_저장() {
+        // given
+        given(userService.findById(anyLong())).willReturn(mock(User.class));
+        given(likeRepository.save(any())).willReturn(mock(Likes.class));
+
+        // when & then
+        assertDoesNotThrow(() -> likeService.save(SOURCE_ID, TARGET_ID));
+    }
+
+    @Test
+    void 내가_좋아요를_누른_사람들_조회() {
+        // given
+        Likes like = Likes.builder()
+                .source(mock(User.class))
+                .target(mock(User.class))
+                .build();
+
+        given(userService.findById(SOURCE_ID)).willReturn(mock(User.class));
+        given(likeRepository.findAllBySource(any())).willReturn(List.of(like));
+
+        // when
+        List<Likes> likes = likeService.findAllBySource(SOURCE_ID);
+
+        // then
+        assertThat(likes).isEqualTo(List.of(like));
+        verify(userService, times(1)).findById(SOURCE_ID);
+        verify(likeRepository, times(1)).findAllBySource(any());
+    }
+}

--- a/src/test/java/com/gaejangmo/apiserver/model/like/service/LikeServiceTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/like/service/LikeServiceTest.java
@@ -1,5 +1,6 @@
 package com.gaejangmo.apiserver.model.like.service;
 
+import com.gaejangmo.apiserver.config.oauth.SecurityUser;
 import com.gaejangmo.apiserver.model.like.domain.LikeRepository;
 import com.gaejangmo.apiserver.model.like.domain.Likes;
 import com.gaejangmo.apiserver.model.user.domain.User;
@@ -33,6 +34,8 @@ class LikeServiceTest {
 
     @Mock
     private UserService userService;
+
+    private SecurityUser loginUser = null;
 
     @Test
     void 좋아요_저장() {
@@ -79,20 +82,30 @@ class LikeServiceTest {
     @Test
     void 좋아요_눌렀을_때_true_반환_확인() {
         // given
+        loginUser = SecurityUser.builder().id(SOURCE_ID).build();
+
         given(userService.findById(anyLong())).willReturn(mock(User.class));
         given(likeRepository.findBySourceAndTarget(any(), any())).willReturn(Optional.of(mock(Likes.class)));
 
         // when & then
-        assertThat(likeService.isLiked(SOURCE_ID, TARGET_ID)).isTrue();
+        assertThat(likeService.isLiked(loginUser, TARGET_ID)).isTrue();
     }
 
     @Test
     void 좋아요_눌르지_않았을_때_false_반환_확인() {
         // given
+        loginUser = SecurityUser.builder().id(SOURCE_ID).build();
+
         given(userService.findById(anyLong())).willReturn(mock(User.class));
         given(likeRepository.findBySourceAndTarget(any(), any())).willReturn(Optional.empty());
 
         // when & then
-        assertThat(likeService.isLiked(SOURCE_ID, TARGET_ID)).isFalse();
+        assertThat(likeService.isLiked(loginUser, TARGET_ID)).isFalse();
+    }
+
+    @Test
+    void 로그인되지_않은_상태에서_좋아요가_false_반환하는지_확인() {
+        // when & then
+        assertThat(likeService.isLiked(loginUser, TARGET_ID)).isFalse();
     }
 }

--- a/src/test/java/com/gaejangmo/apiserver/model/like/service/LikeServiceTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/like/service/LikeServiceTest.java
@@ -62,4 +62,16 @@ class LikeServiceTest {
         verify(userService, times(1)).findById(SOURCE_ID);
         verify(likeRepository, times(1)).findAllBySource(any());
     }
+
+    @Test
+    void 좋아요_취소() {
+        // given
+        given(userService.findById(anyLong())).willReturn(mock(User.class));
+        doNothing().when(likeRepository).deleteBySourceAndTarget(any(), any());
+
+        // when & then
+        assertDoesNotThrow(() -> likeService.deleteBySourceAndTarget(SOURCE_ID, TARGET_ID));
+        verify(userService, times(2)).findById(anyLong());
+        verify(likeRepository, times(1)).deleteBySourceAndTarget(any(), any());
+    }
 }

--- a/src/test/java/com/gaejangmo/apiserver/model/like/service/LikeServiceTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/like/service/LikeServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -73,5 +74,25 @@ class LikeServiceTest {
         assertDoesNotThrow(() -> likeService.deleteBySourceAndTarget(SOURCE_ID, TARGET_ID));
         verify(userService, times(2)).findById(anyLong());
         verify(likeRepository, times(1)).deleteBySourceAndTarget(any(), any());
+    }
+
+    @Test
+    void 좋아요_눌렀을_때_true_반환_확인() {
+        // given
+        given(userService.findById(anyLong())).willReturn(mock(User.class));
+        given(likeRepository.findBySourceAndTarget(any(), any())).willReturn(Optional.of(mock(Likes.class)));
+
+        // when & then
+        assertThat(likeService.isLiked(SOURCE_ID, TARGET_ID)).isTrue();
+    }
+
+    @Test
+    void 좋아요_눌르지_않았을_때_false_반환_확인() {
+        // given
+        given(userService.findById(anyLong())).willReturn(mock(User.class));
+        given(likeRepository.findBySourceAndTarget(any(), any())).willReturn(Optional.empty());
+
+        // when & then
+        assertThat(likeService.isLiked(SOURCE_ID, TARGET_ID)).isFalse();
     }
 }

--- a/src/test/java/com/gaejangmo/apiserver/model/user/controller/UserApiControllerTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/user/controller/UserApiControllerTest.java
@@ -1,5 +1,6 @@
 package com.gaejangmo.apiserver.model.user.controller;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.gaejangmo.apiserver.config.aws.S3Connector;
 import com.gaejangmo.apiserver.model.MockMvcTest;
 import com.gaejangmo.apiserver.model.common.support.WithMockCustomUser;
@@ -7,6 +8,7 @@ import com.gaejangmo.apiserver.model.image.domain.vo.FileFeature;
 import com.gaejangmo.apiserver.model.image.dto.FileResponseDto;
 import com.gaejangmo.apiserver.model.user.domain.vo.Motto;
 import com.gaejangmo.apiserver.model.user.dto.UserResponseDto;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -14,10 +16,13 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static com.gaejangmo.apiserver.model.user.testdata.UserTestData.RESPONSE_DTO;
+import static com.gaejangmo.apiserver.model.user.testdata.UserTestData.RESPONSE_DTO_NOT_INCLUDE_ISLIKED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -31,23 +36,26 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@Slf4j
 class UserApiControllerTest extends MockMvcTest {
     private static final String USER_API = getApiUrl(UserApiController.class);
 
     @MockBean
     private S3Connector s3Connector;
 
-    private FieldDescriptor[] userResponseDtoDescriptors = {fieldWithPath("id").type(JsonFieldType.NUMBER).description("식별자"),
+    private List<FieldDescriptor> userResponseDtoDescriptors = List.of(
+            fieldWithPath("id").type(JsonFieldType.NUMBER).description("식별자"),
             fieldWithPath("oauthId").type(JsonFieldType.NUMBER).description("oauth의 id"),
             fieldWithPath("username").type(JsonFieldType.STRING).description("사용자 이름"),
             fieldWithPath("email").type(JsonFieldType.STRING).description("사용자 이메일"),
             fieldWithPath("motto").type(JsonFieldType.STRING).description("좌우명"),
             fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("프로필 사진"),
-            fieldWithPath("introduce").type(JsonFieldType.STRING).description("소개")};
+            fieldWithPath("introduce").type(JsonFieldType.STRING).description("소개")
+    );
 
 
     @Test
-    @WithMockCustomUser
+    @WithMockCustomUser(id = "3", oauthId = "47378236", username = "kmdngyu", email = "abc2@gmail.com")
     void 사용자_로그인_시_정보_반환() throws Exception {
         // when
         ResultActions resultActions = mockMvc.perform(get(USER_API + "/logined")
@@ -67,12 +75,16 @@ class UserApiControllerTest extends MockMvcTest {
 
         UserResponseDto userResponseDto = OBJECT_MAPPER.readValue(contentAsByteArray, UserResponseDto.class);
 
-        assertThat(userResponseDto.getId()).isEqualTo(RESPONSE_DTO.getId());
+        assertThat(userResponseDto).isEqualTo(RESPONSE_DTO_NOT_INCLUDE_ISLIKED);
     }
 
     @Test
-    @WithAnonymousUser
+    @WithMockCustomUser
     void username으로_유저_정보_받기() throws Exception {
+        // given
+        List<FieldDescriptor> userAndLikedResponseDtoDescriptors = new ArrayList<>(userResponseDtoDescriptors);
+        userAndLikedResponseDtoDescriptors.add(fieldWithPath("isLiked").type(JsonFieldType.BOOLEAN).description("좋아요 여부"));
+
         // when
         ResultActions resultActions = mockMvc.perform(
                 RestDocumentationRequestBuilders.get("/api/v1/users/{name}", RESPONSE_DTO.getUsername())
@@ -85,7 +97,7 @@ class UserApiControllerTest extends MockMvcTest {
                         pathParameters(
                                 parameterWithName("name").description("검색하고 싶은 유저의 이름")
                         ),
-                        responseFields(userResponseDtoDescriptors)
+                        responseFields(userAndLikedResponseDtoDescriptors)
                 ));
 
         // then
@@ -96,6 +108,50 @@ class UserApiControllerTest extends MockMvcTest {
         UserResponseDto userResponseDto = OBJECT_MAPPER.readValue(contentAsByteArray, UserResponseDto.class);
 
         assertThat(userResponseDto).isEqualTo(RESPONSE_DTO);
+    }
+
+    @Test
+    @WithMockCustomUser
+    void 로그인된_사용자가_좋아요한_사용자_목록_조회() throws Exception {
+        // when
+        ResultActions resultActions = mockMvc.perform(get(USER_API + "/likes")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("user/showLikeUser",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("식별자"),
+                                fieldWithPath("[].oauthId").type(JsonFieldType.NUMBER).description("oauth의 id"),
+                                fieldWithPath("[].username").type(JsonFieldType.STRING).description("사용자 이름"),
+                                fieldWithPath("[].email").type(JsonFieldType.STRING).description("사용자 이메일"),
+                                fieldWithPath("[].motto").type(JsonFieldType.STRING).description("좌우명"),
+                                fieldWithPath("[].imageUrl").type(JsonFieldType.STRING).description("프로필 사진"),
+                                fieldWithPath("[].introduce").type(JsonFieldType.STRING).description("소개"),
+                                fieldWithPath("[].isLiked").type(JsonFieldType.BOOLEAN).description("좋아요 여부")
+                        )
+                ));
+
+        // then
+        byte[] contentAsByteArray = resultActions.andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andReturn().getResponse().getContentAsByteArray();
+
+        List<UserResponseDto> userResponseDto = OBJECT_MAPPER.readValue(contentAsByteArray, new TypeReference<>() {
+        });
+
+        assertThat(userResponseDto).isEqualTo(
+                List.of(UserResponseDto.builder()
+                        .id(3L)
+                        .oauthId(47378236L)
+                        .username("kmdngyu")
+                        .email("abc2@gmail.com")
+                        .motto("폭풍개발자")
+                        .imageUrl("https://previews.123rf.com/images/aquir/aquir1311/aquir131100316/23569861-%EC%83%98%ED%94%8C-%EC%A7%80-%EB%B9%A8%EA%B0%84%EC%83%89-%EB%9D%BC%EC%9A%B4%EB%93%9C-%EC%8A%A4%ED%83%AC%ED%94%84.jpg")
+                        .introduce("안녕 난 규동")
+                        .isLiked(true)
+                        .build()));
     }
 
     @Test

--- a/src/test/java/com/gaejangmo/apiserver/model/user/service/UserServiceTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/user/service/UserServiceTest.java
@@ -1,5 +1,7 @@
 package com.gaejangmo.apiserver.model.user.service;
 
+import com.gaejangmo.apiserver.model.like.domain.Likes;
+import com.gaejangmo.apiserver.model.like.service.LikeService;
 import com.gaejangmo.apiserver.model.user.domain.User;
 import com.gaejangmo.apiserver.model.user.domain.UserRepository;
 import com.gaejangmo.apiserver.model.user.domain.vo.Motto;
@@ -11,14 +13,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(SpringExtension.class)
 class UserServiceTest {
@@ -28,6 +30,8 @@ class UserServiceTest {
     private UserService userService;
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private LikeService likeService;
 
     @Test
     void OauthId_유저_조회() {
@@ -60,5 +64,23 @@ class UserServiceTest {
         //then
         assertThat(actual.getMotto()).isEqualTo(updatedMotto.value());
         verify(userRepository,times(1)).findById(USER_ID);
+    }
+
+    @Test
+    void 내가_좋아요를_누른_사람들을_조회() {
+        // given
+        Likes like = Likes.builder()
+                .source(mock(User.class))
+                .target(UserTestData.ENTITY)
+                .build();
+
+        given(likeService.findAllBySource(anyLong())).willReturn(List.of(like));
+
+        // when
+        List<UserResponseDto> actual = userService.findUserResponseDtoBySourceId(1L);
+
+        // then
+        assertThat(actual).isEqualTo(List.of(UserTestData.RESPONSE_DTO));
+        verify(likeService, times(1)).findAllBySource(1L);
     }
 }

--- a/src/test/java/com/gaejangmo/apiserver/model/user/service/UserServiceTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/user/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.gaejangmo.apiserver.model.user.service;
 
+import com.gaejangmo.apiserver.config.oauth.SecurityUser;
 import com.gaejangmo.apiserver.model.like.domain.Likes;
 import com.gaejangmo.apiserver.model.like.service.LikeService;
 import com.gaejangmo.apiserver.model.user.domain.User;
@@ -35,19 +36,21 @@ class UserServiceTest {
 
     @Test
     void OauthId_유저_조회() {
-        given(userRepository.findByOauthId(anyLong())).willReturn(Optional.of(UserTestData.ENTITY));
+        given(userRepository.findByOauthId(anyLong())).willReturn(Optional.of(UserTestData.ENTITY_NOT_INCLUDE_ISLIKED));
 
         UserResponseDto result = userService.findUserResponseDtoByOauthId(1234L);
 
-        assertThat(result).isEqualTo(UserTestData.RESPONSE_DTO);
+        assertThat(result).isEqualTo(UserTestData.RESPONSE_DTO_NOT_INCLUDE_ISLIKED);
     }
 
     @Test
-    void username_유저_조회(){
+    void username_유저_조회() {
+        SecurityUser loginUser = SecurityUser.builder().id(2L).build();
         given(userRepository.findByUsername(anyString())).willReturn(Optional.of(UserTestData.ENTITY));
+        given(likeService.isLiked(any(), anyLong())).willReturn(false);
 
         User user = UserTestData.ENTITY;
-        UserResponseDto result = userService.findUserResponseDtoByName(user.getUsername());
+        UserResponseDto result = userService.findUserResponseDtoByName(user.getUsername(), loginUser);
 
         assertThat(result).isEqualTo(UserTestData.RESPONSE_DTO);
     }
@@ -63,7 +66,7 @@ class UserServiceTest {
 
         //then
         assertThat(actual.getMotto()).isEqualTo(updatedMotto.value());
-        verify(userRepository,times(1)).findById(USER_ID);
+        verify(userRepository, times(1)).findById(USER_ID);
     }
 
     @Test
@@ -80,7 +83,17 @@ class UserServiceTest {
         List<UserResponseDto> actual = userService.findUserResponseDtoBySourceId(1L);
 
         // then
-        assertThat(actual).isEqualTo(List.of(UserTestData.RESPONSE_DTO));
+        assertThat(actual).isEqualTo(
+                List.of(UserResponseDto.builder()
+                        .id(1L)
+                        .oauthId(20608121L)
+                        .username("JunHoPark93")
+                        .email("abc@gmail.com")
+                        .motto("장비충개발자")
+                        .imageUrl("https://previews.123rf.com/images/aquir/aquir1311/aquir131100316/23569861-%EC%83%98%ED%94%8C-%EC%A7%80-%EB%B9%A8%EA%B0%84%EC%83%89-%EB%9D%BC%EC%9A%B4%EB%93%9C-%EC%8A%A4%ED%83%AC%ED%94%84.jpg")
+                        .introduce("안녕 난 제이")
+                        .isLiked(true)
+                        .build()));
         verify(likeService, times(1)).findAllBySource(1L);
     }
 }

--- a/src/test/java/com/gaejangmo/apiserver/model/user/testdata/UserTestData.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/user/testdata/UserTestData.java
@@ -17,6 +17,15 @@ public class UserTestData {
             .introduce("안녕 난 제이")
             .build();
 
+    public static final User ENTITY_NOT_INCLUDE_ISLIKED = User.builder()
+            .oauthId(47378236L)
+            .username("kmdngyu")
+            .email(Email.of("abc2@gmail.com"))
+            .motto(Motto.of("폭풍개발자"))
+            .imageUrl(Link.of("https://previews.123rf.com/images/aquir/aquir1311/aquir131100316/23569861-%EC%83%98%ED%94%8C-%EC%A7%80-%EB%B9%A8%EA%B0%84%EC%83%89-%EB%9D%BC%EC%9A%B4%EB%93%9C-%EC%8A%A4%ED%83%AC%ED%94%84.jpg"))
+            .introduce("안녕 난 규동")
+            .build();
+
     public static final UserResponseDto RESPONSE_DTO = UserResponseDto.builder()
             .id(1L)
             .oauthId(20608121L)
@@ -25,9 +34,23 @@ public class UserTestData {
             .motto("장비충개발자")
             .imageUrl("https://previews.123rf.com/images/aquir/aquir1311/aquir131100316/23569861-%EC%83%98%ED%94%8C-%EC%A7%80-%EB%B9%A8%EA%B0%84%EC%83%89-%EB%9D%BC%EC%9A%B4%EB%93%9C-%EC%8A%A4%ED%83%AC%ED%94%84.jpg")
             .introduce("안녕 난 제이")
+            .isLiked(false)
             .build();
+
+    public static final UserResponseDto RESPONSE_DTO_NOT_INCLUDE_ISLIKED = UserResponseDto.builder()
+            .id(3L)
+            .oauthId(47378236L)
+            .username("kmdngyu")
+            .email("abc2@gmail.com")
+            .motto("폭풍개발자")
+            .imageUrl("https://previews.123rf.com/images/aquir/aquir1311/aquir131100316/23569861-%EC%83%98%ED%94%8C-%EC%A7%80-%EB%B9%A8%EA%B0%84%EC%83%89-%EB%9D%BC%EC%9A%B4%EB%93%9C-%EC%8A%A4%ED%83%AC%ED%94%84.jpg")
+            .introduce("안녕 난 규동")
+            .isLiked(null)
+            .build();
+
 
     static {
         ReflectionTestUtils.setField(UserTestData.ENTITY, "id", 1L);
+        ReflectionTestUtils.setField(UserTestData.ENTITY_NOT_INCLUDE_ISLIKED, "id", 3L);
     }
 }

--- a/src/test/java/com/gaejangmo/apiserver/model/userproduct/service/UserProductServiceTest.java
+++ b/src/test/java/com/gaejangmo/apiserver/model/userproduct/service/UserProductServiceTest.java
@@ -1,6 +1,8 @@
 package com.gaejangmo.apiserver.model.userproduct.service;
 
+import com.gaejangmo.apiserver.config.oauth.SecurityUser;
 import com.gaejangmo.apiserver.model.common.domain.vo.Link;
+import com.gaejangmo.apiserver.model.like.service.LikeService;
 import com.gaejangmo.apiserver.model.product.domain.Product;
 import com.gaejangmo.apiserver.model.product.service.ProductService;
 import com.gaejangmo.apiserver.model.product.testdata.ProductTestData;
@@ -14,6 +16,7 @@ import com.gaejangmo.apiserver.model.userproduct.domain.vo.ProductType;
 import com.gaejangmo.apiserver.model.userproduct.service.dto.UserProductLatestResponseDto;
 import com.gaejangmo.apiserver.model.userproduct.service.dto.UserProductResponseDto;
 import com.gaejangmo.apiserver.model.userproduct.service.exception.NotUserProductOwnerException;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
+@Slf4j
 @ExtendWith(MockitoExtension.class)
 class UserProductServiceTest {
     private static final long USER_PRODUCT_ID = 15L;
@@ -52,6 +56,8 @@ class UserProductServiceTest {
     private UserProductRepository userProductRepository;
     @Mock
     private UserService userService;
+    @Mock
+    private LikeService likeService;
 
     private UserProduct userProduct;
     private UserProduct mockUserProduct;
@@ -192,9 +198,11 @@ class UserProductServiceTest {
                 .collect(Collectors.toList()));
 
         when(userProductRepository.findAll(pageable)).thenReturn(pagedUserProducts);
+        when(likeService.isLiked(any(), anyLong())).thenReturn(true);
 
         // when
-        List<UserProductLatestResponseDto> results = userProductService.findAllByPageable(pageable);
+        List<UserProductLatestResponseDto> results =
+                userProductService.findAllByPageable(pageable, SecurityUser.builder().id(1L).build());
 
         // then
         assertThat(results)
@@ -203,7 +211,8 @@ class UserProductServiceTest {
                         new UserProductLatestResponseDto((long) size,
                                 ProductType.MOUSE, ProductTestData.ENTITY.getImageUrl(), ProductTestData.ENTITY.getProductName(),
                                 UserTestData.ENTITY.getImageUrl(), UserTestData.ENTITY.getUsername(), UserTestData.ENTITY.getMotto(),
-                                null));
+                                true, null));
+        verify(likeService, times(size)).isLiked(any(), anyLong());
     }
 
     private UserProduct createUserProduct(final long id) {

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -51,3 +51,6 @@ values ('ㅎㅎ장비좋아요ㅋㅋㅋㅋ', '2', '1', '3');
 
 insert into user_product(comment, product_type, product_id, user_id)
 values ('ㅎㅎ장비좋아요ㅋㅋㅋㅋ', '1', '2', '1');
+
+insert into likes(user_source_id, user_target_id)
+values ('1', '3')


### PR DESCRIPTION
## 좋아요 기능 구현하면서 공유할 내용 (클래스 이름, 클래스간 의존성 추가, 기능 구현을 위한 메서드 수정)



### 도메인 클래스만 s가 붙는다. Repository나 Service, Controller에는 붙지 않는다.

`Likes`, `LikeRepository`, `LikeService`, `LikeController`

### UserService를 의존하게 된다.

* 좋아요 정보 저장 시 `userSerivce.findById()` 사용

### UserService에서

* `findUserResponseDtoBySourceId(final Long sourceId) ` 추가

  * 내가 좋아요를 누른 사용자 모두 조회

* `findUserResponseDtoByName(final String username, final SecurityUser loginUser)` 메서드 수정

  * 상세 페이지 조회 시 로그인한 사용자가 좋아요를 눌렀는지 여부 판단

  
### SecurityUser 를 인자로 넘겨주는 방식에 대하여

* 현재 코드는 로그인과 비로그인 상태를 구분짓기 위한 if 분기 처리를 `likeService.isLiked()` 메서드에 전부 위임한 상태입니다.

* 이를 개선하기 위한 피드백을 주시면 감사하겠습니다.

### 순환 참조에 대하여

* `LikeService` 와  `UserService`가 순환 참조되는 상황이 왔었습니다.

* 이를 해결하기 위해 일단 현재는 `LikeService`가 `UserRepository`를 의존하게 수정했습니다.
   * 코드의 중복이 발생하고 있습니다. `findById()`


계속 기능 구현해 나갈 예정입니다.

resolves: #65 