### PR TITLE
test yml loading 경로 변경

### DIFF
--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -22,3 +22,6 @@ spring:
 ---
 spring:
   profiles: test
+  cloud:
+    config:
+      uri: http://15.165.84.137:8888


### PR DESCRIPTION
서버에 젠킨스를 올려서 빌드하는게 무리가 가서 어쩔수 없이 로컬로 돌림. 로컬에서 빌드하고 테스트하고 jar만 서버로 던져서 실행하는 방식으로 변경하려면 yml을 로딩하는데 문제가 있어서 경로를 수정함